### PR TITLE
fix(scss-imports): json configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -42,6 +42,11 @@
               "src/styles/index.scss",
               "src/assets/fonts/fonts.css"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles/"
+              ]
+            },
             "scripts": []
           },
           "configurations": {
@@ -108,6 +113,11 @@
               "src/styles/index.scss",
               "src/assets/fonts/fonts.css"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles/"
+              ]
+            },
             "scripts": []
           }
         }


### PR DESCRIPTION
I could not use module aliases in CSS.

`@use 'variables' as *;`
