### PR TITLE
Feat/obt 7/mobile authentication page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,5 +20,5 @@ export class AppComponent {
 
   // isMobile: boolean = false;
 
-  userIsLoggedIn: boolean = true;
+  userIsLoggedIn: boolean = false;
 }

--- a/src/app/features/authentication/authentication-common.scss
+++ b/src/app/features/authentication/authentication-common.scss
@@ -1,9 +1,14 @@
 @use 'sass:map';
 
 @use 'variables' as *;
-@use 'spacing' as *;
-@use 'color-palette' as *;
-@use 'shape' as *;
+@use 'spacing' as spacing;
+@use 'color-palette' as color-palette;
+@use 'shape' as shape;
+@use 'breakpoints' as breakpoints;
+
+@mixin host-style {
+  padding: spacing.$default;
+}
 
 app-login,
 app-register,
@@ -12,23 +17,23 @@ app-forgot-password {
     display: grid;
     align-content: center;
     justify-items: center;
-    background: map.get($color-palette, 'gray', 'default');
+    background: map.get(color-palette.$gray, 'default');
   }
 }
 
 .form-container {
   display: flex;
   flex-direction: column;
-  gap: map.get($spacing, 'default');
+  gap: spacing.$default;
 
-  background: map.get($color-palette, 'common', 'white');
+  background: map.get(color-palette.$common, 'white');
   box-shadow: 0px 0 3px 0px rgb(0 0 0 / 15%);
 
   width: 100%;
   max-width: 400px;
 
-  padding: map.get($spacing, 'default');
-  border-radius: map.get($border-radius, 'default');
+  padding: spacing.$default;
+  border-radius: shape.$default;
 
   text-align: center;
 
@@ -46,5 +51,5 @@ app-forgot-password {
 }
 
 .light-text {
-  color: map.get($color-palette, 'gray', 'variant-4');
+  color: map.get(color-palette.$gray, 'variant-4');
 }

--- a/src/app/features/authentication/authentication-common.scss
+++ b/src/app/features/authentication/authentication-common.scss
@@ -25,7 +25,7 @@ app-forgot-password {
   box-shadow: 0px 0 3px 0px rgb(0 0 0 / 15%);
 
   width: 100%;
-  max-width: 24rem;
+  max-width: 400px;
 
   padding: map.get($spacing, 'default');
   border-radius: map.get($border-radius, 'default');

--- a/src/app/features/authentication/forgot-password/forgot-password.component.html
+++ b/src/app/features/authentication/forgot-password/forgot-password.component.html
@@ -17,6 +17,7 @@
       variant="outlined"
       color="primary-default"
       class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
@@ -31,7 +32,7 @@
 
   <p>
     Go back to
-    <a routerLink="/{{paths.login.path}}" class="redirect-link underline">Login</a>
+    <a routerLink="/{{ paths.login.path }}" class="redirect-link underline">Login</a>
     page
   </p>
 </div>

--- a/src/app/features/authentication/forgot-password/forgot-password.component.scss
+++ b/src/app/features/authentication/forgot-password/forgot-password.component.scss
@@ -1,0 +1,9 @@
+@use 'breakpoints' as breakpoints;
+
+@use '../authentication-common' as authentication-common;
+
+@media screen and (max-width: breakpoints.$md) {
+  :host {
+    @include authentication-common.host-style;
+  }
+}

--- a/src/app/features/authentication/login/login.component.html
+++ b/src/app/features/authentication/login/login.component.html
@@ -20,10 +20,11 @@
     <app-form-field
       variant="outlined"
       color="primary-default"
+      class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
-      class="mb-default"
     >
       <app-input-label>Email</app-input-label>
 
@@ -33,16 +34,17 @@
     <app-form-field
       variant="outlined"
       color="primary-default"
+      class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
-      class="mb-default"
     >
       <app-input-label>
         <span class="label-password-container">
           Password
 
-          <a routerLink="/{{paths.forgotPassword.path}}" class="redirect-link">
+          <a routerLink="/{{ paths.forgotPassword.path }}" class="redirect-link">
             Forgot your password?
           </a>
         </span>
@@ -56,7 +58,7 @@
 
   <p>
     Don't have an account?
-    <a routerLink="/{{paths.register.path}}" class="redirect-link underline">Sign Up</a>
+    <a routerLink="/{{ paths.register.path }}" class="redirect-link underline">Sign Up</a>
   </p>
 </div>
 

--- a/src/app/features/authentication/login/login.component.scss
+++ b/src/app/features/authentication/login/login.component.scss
@@ -1,5 +1,15 @@
+@use 'breakpoints' as breakpoints;
+
+@use '../authentication-common' as authentication-common;
+
 .label-password-container {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+@media screen and (max-width: breakpoints.$md) {
+  :host {
+    @include authentication-common.host-style;
+  }
 }

--- a/src/app/features/authentication/register/register.component.html
+++ b/src/app/features/authentication/register/register.component.html
@@ -12,6 +12,7 @@
       variant="outlined"
       color="primary-default"
       class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
@@ -25,6 +26,7 @@
       variant="outlined"
       color="primary-default"
       class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
@@ -38,6 +40,7 @@
       variant="outlined"
       color="primary-default"
       class="mb-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
@@ -51,6 +54,7 @@
       class="mb-default"
       variant="outlined"
       color="primary-default"
+      fullWidth
       [labelOptions]="{
         position: 'top',
       }"
@@ -69,7 +73,7 @@
 
   <p>
     Already have an account?
-    <a routerLink="/{{paths.login.path}}" class="redirect-link underline">Login</a>
+    <a routerLink="/{{ paths.login.path }}" class="redirect-link underline">Login</a>
   </p>
 </div>
 

--- a/src/app/features/authentication/register/register.component.scss
+++ b/src/app/features/authentication/register/register.component.scss
@@ -1,0 +1,9 @@
+@use 'breakpoints' as breakpoints;
+
+@use '../authentication-common' as authentication-common;
+
+@media screen and (max-width: breakpoints.$md) {
+  :host {
+    @include authentication-common.host-style;
+  }
+}

--- a/src/app/shared/components/form/form-field/form-field.component.scss
+++ b/src/app/shared/components/form/form-field/form-field.component.scss
@@ -25,6 +25,14 @@ $input-spacing-default: map.get($spacing, 'sm');
     max-width: $input-maximum-size;
   }
 
+  &.app-form-field-full-width {
+    &,
+    & .app-input,
+    & .app-select {
+      max-width: none;
+    }
+  }
+
   & .app-label,
   & .app-input,
   & .app-select {

--- a/src/app/shared/components/form/form-field/form-field.component.ts
+++ b/src/app/shared/components/form/form-field/form-field.component.ts
@@ -3,9 +3,9 @@ import {
   Component,
   Input,
   ViewEncapsulation,
-  ElementRef,
   ContentChild,
   ViewChild,
+  booleanAttribute,
 } from '@angular/core';
 
 import { type ThemeVariant, type ThemeColor } from '@shared/models/types';
@@ -51,6 +51,7 @@ import { AppFormFieldControl } from './form-field-control';
     '[class.app-form-field-variant-outlined]': 'variant === "outlined"',
     '[class.app-form-field-focused]': 'formFieldControl.focused',
     '[class.app-form-field-has-value]': 'formFieldControl.hasValue',
+    '[class.app-form-field-full-width]': 'fullWidth',
   },
 })
 export class AppFormField {
@@ -58,6 +59,24 @@ export class AppFormField {
   @Input({ required: true }) color!: ThemeColor;
   @Input({ required: true }) labelOptions!: TextFieldLabelOptions;
   @Input() error!: string;
+
+  /**
+   * @summary - Remove max width if needed.
+   *
+   * @type {boolean}
+   */
+  @Input({
+    transform: booleanAttribute,
+  })
+  get fullWidth(): boolean {
+    return this._fullWidth;
+  }
+
+  set fullWidth(value: boolean) {
+    this._fullWidth = value;
+  }
+
+  private _fullWidth: boolean = false;
 
   @ContentChild(AppFormFieldControl)
   public formFieldControl!: AppFormFieldControl;

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -1,3 +1,4 @@
+// Deprecated
 $breakpoints: (
   'sm': 570px,
   'md': 768px,
@@ -5,3 +6,10 @@ $breakpoints: (
   'xl': 1024px,
   'xxl': 1280px,
 );
+// Deprecated above
+
+$sm: 570px;
+$md: 768px;
+$lg: 850px;
+$xl: 1024px;
+$xxl: 1280px;


### PR DESCRIPTION
### What changes I want to bring in production with this PR?

Mobile versions for:

- `/login`
- `/register`
- `/forgot-password`

`fullWidth` feature for `app-form-field`, which removes the `max-width` style.

#### Configurations ⚒️

_None_

#### UI & UX 🖌️

_None_

#### Optimizations 📈

Using `@use` with namespaces.

#### Bug fixing 🔨

_None_

#### Preview

_None_