### PR TITLE
Feat/obt 8/mobile overview page

### DIFF
--- a/src/app/core/layout/router-container/router-container.component.scss
+++ b/src/app/core/layout/router-container/router-container.component.scss
@@ -16,6 +16,10 @@
 
     width: 100%;
     height: 100%;
+
+    &:not(app-goals) {
+      grid-auto-rows: max-content;
+    }
   }
 
   &.remove-overflow router-outlet + * {

--- a/src/app/core/layout/widget-box/widget-box.component.html
+++ b/src/app/core/layout/widget-box/widget-box.component.html
@@ -1,4 +1,6 @@
-<ng-content select="[app-widget-box-title]"></ng-content>
-<ng-content select="[app-widget-box-title-info]"></ng-content>
+<div class="header">
+  <ng-content select="[app-widget-box-title]"></ng-content>
+  <ng-content select="[app-widget-box-title-info]"></ng-content>
+</div>
 
 <ng-content></ng-content>

--- a/src/app/features/home/category-expenses/category-expenses.component.html
+++ b/src/app/features/home/category-expenses/category-expenses.component.html
@@ -1,5 +1,6 @@
 <app-widget-box>
-  <h4 app-widget-box-title>Category Expenses for last month</h4>
+  <h4 app-widget-box-title>Category Expenses</h4>
+  <h5 app-widget-box-title-info>For the last month</h5>
 
   <div class="canvas-container">
     <canvas id="pie-chart" #pieChart>Your device doesn't support canvas element.</canvas>

--- a/src/app/features/home/category-expenses/category-expenses.component.scss
+++ b/src/app/features/home/category-expenses/category-expenses.component.scss
@@ -12,6 +12,7 @@ app-widget-box {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: map.get($spacing, 'default');
 }
 

--- a/src/app/features/home/category-expenses/category-expenses.component.ts
+++ b/src/app/features/home/category-expenses/category-expenses.component.ts
@@ -32,8 +32,8 @@ export class CategoryExpensesComponent implements AfterViewInit {
     width: number;
     height: number;
   } = {
-    width: 300,
-    height: 300,
+    width: 200,
+    height: 200,
   };
 
   /**
@@ -87,17 +87,13 @@ export class CategoryExpensesComponent implements AfterViewInit {
    * @type {ElementRef<HTMLCanvasElement> | null}
    * @public
    */
-  @ViewChild('pieChart') public canvasElement: ElementRef<HTMLCanvasElement> | null =
-    null;
+  @ViewChild('pieChart') public canvasElement: ElementRef<HTMLCanvasElement> | null = null;
 
   constructor(...args: Array<unknown>);
   constructor() {
     this._dataOnlyValues = this.data.map(item => item.value);
 
-    this._totalValues = this._dataOnlyValues.reduce(
-      (total, currentItem) => total + currentItem,
-      0
-    );
+    this._totalValues = this._dataOnlyValues.reduce((total, currentItem) => total + currentItem, 0);
   }
 
   trackByCustom(_index: number, item: CategoryExpenseItem) {

--- a/src/app/features/home/home.component.scss
+++ b/src/app/features/home/home.component.scss
@@ -11,12 +11,13 @@
 
 .row-2 {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 1fr auto;
   gap: spacing.$md;
 }
 
-@media screen and (max-width: breakpoints.$sm) {
-  .row-1 {
+@media screen and (max-width: breakpoints.$lg) {
+  .row-1,
+  .row-2 {
     grid-template-columns: 1fr;
   }
 }

--- a/src/app/features/home/home.component.scss
+++ b/src/app/features/home/home.component.scss
@@ -1,15 +1,22 @@
 @use 'sass:map';
 
-@use 'spacing' as *;
+@use 'spacing' as spacing;
+@use 'breakpoints' as breakpoints;
 
 .row-1 {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: map.get($spacing, 'md');
+  gap: spacing.$md;
 }
 
 .row-2 {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: map.get($spacing, 'md');
+  gap: spacing.$md;
+}
+
+@media screen and (max-width: breakpoints.$sm) {
+  .row-1 {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/features/home/money-statistics/money-statistics.component.html
+++ b/src/app/features/home/money-statistics/money-statistics.component.html
@@ -1,5 +1,7 @@
 <app-widget-box>
   <h4 app-widget-box-title>Money Statistics</h4>
 
-  <canvas id="line-chart" #lineChart>Your device doesn't support canvas element.</canvas>
+  <div class="canvas-wrapper" #canvasWrapper>
+    <canvas id="line-chart" #lineChart>Your device doesn't support canvas element.</canvas>
+  </div>
 </app-widget-box>

--- a/src/app/features/home/money-statistics/money-statistics.component.scss
+++ b/src/app/features/home/money-statistics/money-statistics.component.scss
@@ -1,3 +1,26 @@
+@use 'breakpoints' as breakpoints;
+
 app-widget-box {
   height: 100%;
+}
+
+.canvas-wrapper {
+  overflow: hidden;
+
+  aspect-ratio: 16 / 6;
+
+  width: 100%;
+  height: 100%;
+}
+
+canvas {
+  display: block;
+  image-rendering: crisp-edges;
+  object-fit: cover;
+}
+
+@media screen and (max-width: breakpoints.$xl) and (orientation: portrait) {
+  .canvas-wrapper {
+    aspect-ratio: 4 / 3;
+  }
 }

--- a/src/app/features/home/money-statistics/money-statistics.component.ts
+++ b/src/app/features/home/money-statistics/money-statistics.component.ts
@@ -1,55 +1,48 @@
-import { type AfterViewInit, Component, type ElementRef, ViewChild } from '@angular/core';
+import {
+  type AfterViewInit,
+  type OnDestroy,
+  ElementRef,
+  Component,
+  ViewChild,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+
+import { debounceTime, fromEvent, Subject, takeUntil } from 'rxjs';
 
 import { DEFAULT_TICKS, generateNiceNumbersArray } from '@script/nice-numbers';
 
+import { MediaQueryService } from '@shared/services/media-query/media-query.service';
+
 import {
-  DataSourceItemKey,
   type DataSourceOptions,
   type GraphConfiguration,
+  type CanvasStyle,
+  DataSourceItemKey,
 } from './money-statistics.model';
 
 @Component({
   selector: 'app-money-statistics',
   templateUrl: './money-statistics.component.html',
   styleUrls: ['./money-statistics.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MoneyStatisticsComponent implements AfterViewInit {
-  /**
-   * @summary - Get the pixel ratio for current device.
-   *
-   * In order to fix the blurry canvas.
-   *
-   * @type {number}
-   * @private
-   */
-  private readonly _devicePixelRatio: number = window.devicePixelRatio || 1;
+export class MoneyStatisticsComponent implements AfterViewInit, OnDestroy {
+  private readonly _mediaQueryService: MediaQueryService;
 
   /**
    * @summary - Canvas styling.
    *
    * Sizes are always in pixels.
    *
-   * @type {{
-   *     width: number;
-   *     height: number;
-   *     spacing: number;
-   *     textSize: number;
-   *     font: string;
-   *   }}
+   * @type {CanvasStyle}
    * @private
    */
-  private readonly _canvasStyle: {
-    width: number;
-    height: number;
-    spacing: number;
-    fontSize: number;
-    font: string;
-  } = {
-    width: 800,
-    height: 350,
-    spacing: 16,
-    fontSize: 16,
-    font: "1rem 'Roboto', sans-serif",
+  private readonly _canvasStyle: CanvasStyle = {
+    spacingPXDefault: 16,
+    spacingPX: 16,
+    fontSizePXDefault: 18,
+    fontSizePX: 18,
+    fontFamily: "'Roboto', sans-serif",
   };
 
   /**
@@ -173,13 +166,29 @@ export class MoneyStatisticsComponent implements AfterViewInit {
   private _startingPositionX: number = 0;
 
   /**
+   * @summary - Destroy on cleanup.
+   *
+   * @type {Subject<void>}
+   *
+   * @private
+   * @readonly
+   */
+  private readonly _resizeEventDestroy$: Subject<void> = new Subject<void>();
+
+  /**
    * @summary - Element reference to the HTML Canvas element.
    *
    * @type {ElementRef<HTMLCanvasElement> | null}
    * @public
    */
-  @ViewChild('lineChart') public canvasElement: ElementRef<HTMLCanvasElement> | null =
+  @ViewChild('lineChart') public canvasElement: ElementRef<HTMLCanvasElement> | null = null;
+
+  @ViewChild('canvasWrapper') private readonly _canvasWrapper: ElementRef<HTMLDivElement> | null =
     null;
+
+  constructor(mediaQueryService: MediaQueryService) {
+    this._mediaQueryService = mediaQueryService;
+  }
 
   /**
    * @summary - Render initial canvas element, with basic configuration.
@@ -189,16 +198,31 @@ export class MoneyStatisticsComponent implements AfterViewInit {
    */
   private _renderInitialCanvas(): void {
     const CANVAS_ELEMENT = this.canvasElement && this.canvasElement.nativeElement;
+    const CANVAS_WRAPPER = this._canvasWrapper && this._canvasWrapper.nativeElement;
 
-    if (!CANVAS_ELEMENT || !this._canvasContext) {
+    if (!this._canvasContext || !CANVAS_ELEMENT || !CANVAS_WRAPPER) {
       throw Error('Canvas element not found!');
     }
 
-    CANVAS_ELEMENT.style.width = `${this._canvasStyle.width}px`;
-    CANVAS_ELEMENT.style.height = `${this._canvasStyle.height}px`;
+    const { width: wrapperWidth, height: wrapperHeight } = CANVAS_WRAPPER.getBoundingClientRect();
 
-    CANVAS_ELEMENT.width = this._canvasStyle.width * this._devicePixelRatio;
-    CANVAS_ELEMENT.height = this._canvasStyle.height * this._devicePixelRatio;
+    const isMobile = this._isMobile();
+    const DEVICE_PIXEL_RATIO = window.devicePixelRatio || 1;
+
+    let size = 1;
+
+    if (isMobile) {
+      size = 2;
+    }
+
+    this._canvasStyle.fontSizePX = this._canvasStyle.fontSizePXDefault * size;
+    this._canvasStyle.spacingPX = this._canvasStyle.spacingPXDefault * size;
+
+    CANVAS_ELEMENT.style.width = `${wrapperWidth}px`;
+    CANVAS_ELEMENT.style.height = `${wrapperHeight}px`;
+
+    CANVAS_ELEMENT.width = wrapperWidth * DEVICE_PIXEL_RATIO;
+    CANVAS_ELEMENT.height = wrapperHeight * DEVICE_PIXEL_RATIO;
 
     this._canvasContext.clearRect(0, 0, CANVAS_ELEMENT.width, CANVAS_ELEMENT.height);
 
@@ -253,11 +277,10 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       const ITEM = niceNumberValues[i];
       const FORMATTED_ITEM = formatNumber.format(ITEM);
 
-      this._canvasContext.font = this._canvasStyle.font;
+      this._canvasContext.font = `${this._canvasStyle.fontSizePX}px ${this._canvasStyle.fontFamily}`;
       this._canvasContext.fillText(FORMATTED_ITEM, -999, -999);
 
-      const ITEM_WIDTH_AFTER_RENDER =
-        this._canvasContext.measureText(FORMATTED_ITEM).width;
+      const ITEM_WIDTH_AFTER_RENDER = this._canvasContext.measureText(FORMATTED_ITEM).width;
 
       TEXT_SIZES.push(ITEM_WIDTH_AFTER_RENDER);
     }
@@ -268,17 +291,13 @@ export class MoneyStatisticsComponent implements AfterViewInit {
     for (let i = 0; i < DATA_LENGTH; i++) {
       const ITEM = niceNumberValues[i];
       const FORMATTED_ITEM = formatNumber.format(ITEM);
-      const POSITION_Y = ROW_WIDTH * i + this._canvasStyle.spacing;
+      const POSITION_Y = ROW_WIDTH * i + this._canvasStyle.spacingPX;
 
-      this._canvasContext.font = this._canvasStyle.font;
+      this._canvasContext.font = `${this._canvasStyle.fontSizePX}px ${this._canvasStyle.fontFamily}`;
       this._canvasContext.fillStyle = '#000';
       this._canvasContext.textAlign = 'right';
       this._canvasContext.textBaseline = 'middle';
-      this._canvasContext.fillText(
-        FORMATTED_ITEM,
-        this._startingPositionX,
-        Math.abs(POSITION_Y)
-      );
+      this._canvasContext.fillText(FORMATTED_ITEM, this._startingPositionX, Math.abs(POSITION_Y));
     }
 
     this._renderBackgroundLines(DATA_LENGTH, ROW_WIDTH, CANVAS_ELEMENT.width);
@@ -304,14 +323,8 @@ export class MoneyStatisticsComponent implements AfterViewInit {
 
     const graphConfiguration = this._getGraphConfiguration();
 
-    const {
-      DATA_SOURCE,
-      PADDING_X,
-      RENDERING_AREA_X,
-      DATA_LENGTH,
-      AREA_Y_WIDTH,
-      COLUMN_WIDTH,
-    } = graphConfiguration;
+    const { DATA_SOURCE, PADDING_X, RENDERING_AREA_X, DATA_LENGTH, AREA_Y_WIDTH, COLUMN_WIDTH } =
+      graphConfiguration;
 
     const TEXT_SIZES: Array<number> = DATA_SOURCE.map(
       item => canvasContext.measureText(item).width + PADDING_X
@@ -325,16 +338,12 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       const ITEM = DATA_SOURCE[i];
       const POSITION_X = AREA_Y_WIDTH + i * COLUMN_WIDTH + COLUMN_WIDTH / 2;
 
-      canvasContext.font = this._canvasStyle.font;
+      canvasContext.font = `${this._canvasStyle.fontSizePX}px ${this._canvasStyle.fontFamily}`;
       canvasContext.fillStyle = '#000';
       canvasContext.textAlign = 'center';
       canvasContext.textBaseline = 'bottom';
 
-      canvasContext.fillText(
-        ITEM,
-        i % STEP === 0 ? POSITION_X : -999,
-        CANVAS_ELEMENT.height
-      );
+      canvasContext.fillText(ITEM, i % STEP === 0 ? POSITION_X : -999, CANVAS_ELEMENT.height);
     }
   }
 
@@ -348,24 +357,17 @@ export class MoneyStatisticsComponent implements AfterViewInit {
    * @private
    * @returns {void}
    */
-  private _renderBackgroundLines(
-    dataLength: number,
-    rowWidth: number,
-    canvasWidth: number
-  ): void {
+  private _renderBackgroundLines(dataLength: number, rowWidth: number, canvasWidth: number): void {
     if (!this._canvasContext) {
       throw Error('Canvas context not found!');
     }
 
     for (let i = 0; i < dataLength; i++) {
-      const POSITION_Y = rowWidth * i + this._canvasStyle.spacing;
+      const POSITION_Y = rowWidth * i + this._canvasStyle.spacingPX;
 
       this._canvasContext.beginPath();
 
-      this._canvasContext.moveTo(
-        this._startingPositionX + this._canvasStyle.spacing,
-        POSITION_Y
-      );
+      this._canvasContext.moveTo(this._startingPositionX + this._canvasStyle.spacingPX, POSITION_Y);
       this._canvasContext.lineTo(canvasWidth, POSITION_Y);
       this._canvasContext.strokeStyle = '#c9c9c9';
       this._canvasContext.lineWidth = 1;
@@ -414,9 +416,9 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       const CURRENT_POSITION_Y =
         RENDERING_AREA_Y -
         (CURRENT_PERCENT / FULL_PERCENT) * RENDERING_AREA_Y +
-        this._canvasStyle.fontSize;
+        this._canvasStyle.fontSizePX;
 
-      // lines
+      // Lines
       const NEXT_VALUE = ALL_VALUES[i + 1];
       const NEXT_PERCENT = (NEXT_VALUE / MAXIMUM_VALUE) * FULL_PERCENT;
       const NEXT_POSITION_X = AREA_Y_WIDTH + (i + 1) * COLUMN_WIDTH + COLUMN_WIDTH / 2;
@@ -424,7 +426,7 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       const NEXT_POSITION_Y =
         RENDERING_AREA_Y -
         (NEXT_PERCENT / FULL_PERCENT) * RENDERING_AREA_Y +
-        this._canvasStyle.fontSize;
+        this._canvasStyle.fontSizePX;
 
       this._canvasContext.beginPath();
 
@@ -468,24 +470,29 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       throw Error('Canvas context not found!');
     }
 
+    let arcRadius = 4.5;
+
+    const isMobile = this._isMobile();
+
     const DATA_SOURCE = this._dataSource.xAxis.data;
-    const ALL_VALUES = this._dataSource.series
-      .map(item => item[DataSourceItemKey.VALUE])
-      .flat();
+    const ALL_VALUES = this._dataSource.series.map(item => item[DataSourceItemKey.VALUE]).flat();
     const DATA_LENGTH = ALL_VALUES.length;
     const MAXIMUM_VALUE = Math.max(...ALL_VALUES);
 
-    const AREA_Y_WIDTH = this._startingPositionX + this._canvasStyle.spacing;
+    const AREA_Y_WIDTH = this._startingPositionX + this._canvasStyle.spacingPX;
     const RENDERING_AREA_X = CANVAS_ELEMENT.width - AREA_Y_WIDTH;
     const COLUMN_WIDTH = RENDERING_AREA_X / DATA_SOURCE.length;
     const RENDERING_AREA_Y =
-      CANVAS_ELEMENT.height - this._canvasStyle.spacing * 2 - this._canvasStyle.fontSize;
-    const PADDING_X = this._canvasStyle.spacing * 2;
+      CANVAS_ELEMENT.height - this._canvasStyle.spacingPX * 2 - this._canvasStyle.fontSizePX;
+    const PADDING_X = this._canvasStyle.spacingPX * 2;
 
     const FULL_PERCENT = 100;
-    const ARC_RADIUS = 4.5;
     const START_ANGLE = 0;
     const END_ANGLE = Math.PI * 2; // 360° means a complete circle
+
+    if (isMobile) {
+      arcRadius = 10;
+    }
 
     return {
       DATA_SOURCE,
@@ -500,26 +507,83 @@ export class MoneyStatisticsComponent implements AfterViewInit {
       PADDING_X,
 
       FULL_PERCENT,
-      ARC_RADIUS,
+      ARC_RADIUS: arcRadius,
       START_ANGLE,
       END_ANGLE,
     };
   }
 
-  ngAfterViewInit() {
-    const CANVAS_ELEMENT = this.canvasElement && this.canvasElement.nativeElement;
-    const CANVAS_CONTEXT =
-      CANVAS_ELEMENT && CANVAS_ELEMENT.getContext('2d', { alpha: false });
+  /**
+   * @summary - Check if device is mobile.
+   *
+   * @private
+   * @returns {void}
+   */
+  private _isMobile(): boolean {
+    return (
+      window.innerWidth <= this._mediaQueryService.breakpointsPX.xl &&
+      window.innerHeight <= this._mediaQueryService.breakpointsPX.xl
+    );
+  }
 
-    if (!CANVAS_ELEMENT || !CANVAS_CONTEXT) {
+  /**
+   * @summary - Paint canvas, all functions stacked together.
+   *
+   * @private
+   * @returns {void}
+   */
+  private _paintCanvas(): void {
+    requestAnimationFrame(() => {
+      this._renderInitialCanvas();
+      this._renderLegendY();
+      this._renderLegendX();
+      this._renderDataGraph();
+    });
+  }
+
+  /**
+   * @summary - Initialize the canvas context.
+   *
+   * @private
+   * @returns {void}
+   */
+  private _initCanvasContext(): void {
+    const CANVAS_ELEMENT = this.canvasElement && this.canvasElement.nativeElement;
+
+    const CANVAS_CONTEXT = CANVAS_ELEMENT && CANVAS_ELEMENT.getContext('2d', { alpha: false });
+
+    if (!CANVAS_CONTEXT) {
       throw Error('Canvas element not queried!');
     }
 
     this._canvasContext = CANVAS_CONTEXT;
+  }
 
-    this._renderInitialCanvas();
-    this._renderLegendY();
-    this._renderLegendX();
-    this._renderDataGraph();
+  /**
+   * @summary - For whenever we destroy the component.
+   *
+   * @private
+   * @returns {void}
+   */
+  private _initCleanup(): void {
+    this._resizeEventDestroy$.next();
+    this._resizeEventDestroy$.complete();
+  }
+
+  ngAfterViewInit(): void {
+    this._initCanvasContext();
+    this._paintCanvas();
+
+    fromEvent(window, 'resize')
+      .pipe(takeUntil(this._resizeEventDestroy$), debounceTime(300))
+      .subscribe({
+        next: () => {
+          this._paintCanvas();
+        },
+      });
+  }
+
+  ngOnDestroy(): void {
+    this._initCleanup();
   }
 }

--- a/src/app/features/home/money-statistics/money-statistics.model.ts
+++ b/src/app/features/home/money-statistics/money-statistics.model.ts
@@ -33,5 +33,13 @@ interface GraphConfiguration {
   END_ANGLE: number;
 }
 
-export type { DataSourceItem, DataSourceOptions, GraphConfiguration };
+interface CanvasStyle {
+  spacingPX: number;
+  spacingPXDefault: number;
+  fontSizePX: number;
+  fontSizePXDefault: number;
+  fontFamily: string;
+}
+
+export type { DataSourceItem, DataSourceOptions, GraphConfiguration, CanvasStyle };
 export { DataSourceItemKey };

--- a/src/app/features/home/top-expenses/top-expenses.component.html
+++ b/src/app/features/home/top-expenses/top-expenses.component.html
@@ -1,32 +1,60 @@
 <app-widget-box>
   <h4 app-widget-box-title>Top expenses last month</h4>
 
-  <table app-table [dataSource]="dataSource">
-    <ng-container [appColumnDef]="expenseItemKey.NAME">
+  <table app-table [dataSource]="dataSource" *ngIf="!isMobile; else mobileCardsContainer">
+    <ng-container [appColumnDef]="ExpenseItemKey.NAME">
       <th app-header-cell *appHeaderCellDef>Name</th>
-      <td app-cell *appCellDef="let element">{{ element[expenseItemKey.NAME] }}</td>
+      <td app-cell *appCellDef="let element">{{ element[ExpenseItemKey.NAME] }}</td>
     </ng-container>
 
-    <ng-container [appColumnDef]="expenseItemKey.CATEGORY">
+    <ng-container [appColumnDef]="ExpenseItemKey.CATEGORY">
       <th app-header-cell *appHeaderCellDef>Category</th>
-      <td app-cell *appCellDef="let element">{{ element[expenseItemKey.CATEGORY] }}</td>
+      <td app-cell *appCellDef="let element">{{ element[ExpenseItemKey.CATEGORY] }}</td>
     </ng-container>
 
-    <ng-container [appColumnDef]="expenseItemKey.PRICE">
+    <ng-container [appColumnDef]="ExpenseItemKey.PRICE">
       <th app-header-cell *appHeaderCellDef>Price</th>
       <td app-cell *appCellDef="let element">
-        {{ element[expenseItemKey.PRICE] | currency: 'USD' }}
+        {{ element[ExpenseItemKey.PRICE] | currency: 'USD' }}
       </td>
     </ng-container>
 
-    <ng-container [appColumnDef]="expenseItemKey.TIMESTAMP">
+    <ng-container [appColumnDef]="ExpenseItemKey.TIMESTAMP">
       <th app-header-cell *appHeaderCellDef>Date</th>
       <td app-cell *appCellDef="let element">
-        {{ element[expenseItemKey.TIMESTAMP] | date: 'dd MMMM yyy' }}
+        {{ element[ExpenseItemKey.TIMESTAMP] | date: 'dd MMMM yyy' }}
       </td>
     </ng-container>
 
     <tr app-header-row *appHeaderRowDef="displayedColumns"></tr>
     <tr app-row *appRowDef="let row; columns: displayedColumns"></tr>
   </table>
+
+  <ng-template #mobileCardsContainer>
+    <div class="mobile-cards-container">
+      <app-card *ngFor="let item of dataSource; trackBy: trackByFnDataSource">
+        <app-card-row>
+          <app-card-key>Name</app-card-key>
+          <app-card-value>{{ item[ExpenseItemKey.NAME] }}</app-card-value>
+        </app-card-row>
+
+        <app-card-row>
+          <app-card-key>Category</app-card-key>
+          <app-card-value>{{ item[ExpenseItemKey.CATEGORY] }}</app-card-value>
+        </app-card-row>
+
+        <app-card-row>
+          <app-card-key>Price</app-card-key>
+          <app-card-value>{{ item[ExpenseItemKey.PRICE] | currency: 'USD' }}</app-card-value>
+        </app-card-row>
+
+        <app-card-row>
+          <app-card-key>Date</app-card-key>
+          <app-card-value>
+            {{ item[ExpenseItemKey.TIMESTAMP] | date: 'dd MMMM yyy' }}
+          </app-card-value>
+        </app-card-row>
+      </app-card>
+    </div>
+  </ng-template>
 </app-widget-box>

--- a/src/app/features/home/top-expenses/top-expenses.component.scss
+++ b/src/app/features/home/top-expenses/top-expenses.component.scss
@@ -1,0 +1,6 @@
+@use 'spacing' as spacing;
+
+.mobile-cards-container {
+  display: grid;
+  gap: spacing.$lg;
+}

--- a/src/app/features/home/top-expenses/top-expenses.component.ts
+++ b/src/app/features/home/top-expenses/top-expenses.component.ts
@@ -1,6 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 
 import { CategoryType } from '@shared/models/enums';
+
+import { MediaQueryService } from '@shared/services/media-query/media-query.service';
+
 import { type ExpenseItem, ExpenseItemKey } from './top-expenses.model';
 
 const TOP_EXPENSES: Array<ExpenseItem> = [
@@ -38,10 +41,60 @@ const DISPLAYED_COLUMNS: Array<string> = [
   selector: 'app-top-expenses',
   templateUrl: './top-expenses.component.html',
   styleUrls: ['./top-expenses.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TopExpensesComponent {
-  public readonly expenseItemKey = ExpenseItemKey;
+  public readonly ExpenseItemKey = ExpenseItemKey;
 
   public dataSource = TOP_EXPENSES;
   public displayedColumns = DISPLAYED_COLUMNS;
+
+  /**
+   * @summary - Render mobile components based on this state.
+   *
+   * @type {boolean}
+   *
+   * @public
+   */
+  public isMobile: boolean = false;
+
+  private readonly _mediaQueryService: MediaQueryService;
+  private readonly _changeDetectorRef: ChangeDetectorRef;
+
+  constructor(mediaQueryService: MediaQueryService, changeDetectorRef: ChangeDetectorRef) {
+    this._mediaQueryService = mediaQueryService;
+    this._changeDetectorRef = changeDetectorRef;
+  }
+
+  /**
+   * @summary - Init the media query subscription.
+   *
+   * @returns {void}
+   * @private
+   */
+  private _initMediaQuerySubscription(): void {
+    this._mediaQueryService.mediaQuery('max', 'lg').subscribe({
+      next: value => {
+        this.isMobile = value;
+        this._changeDetectorRef.markForCheck();
+      },
+    });
+  }
+
+  /**
+   * @summary - Optimize loop fn.
+   *
+   * @param {number} _ - Not used.
+   * @param {ExpenseItem} item - Iteration item.
+   *
+   * @public
+   * @returns {number}
+   */
+  public trackByFnDataSource(_: number, item: ExpenseItem): number {
+    return item[ExpenseItemKey.ID];
+  }
+
+  ngOnInit(): void {
+    this._initMediaQuerySubscription();
+  }
 }

--- a/src/app/features/home/top-expenses/top-expenses.module.ts
+++ b/src/app/features/home/top-expenses/top-expenses.module.ts
@@ -1,14 +1,22 @@
 import { NgModule } from '@angular/core';
-import { DatePipe, CurrencyPipe } from '@angular/common';
+import { CommonModule } from '@angular/common';
 
 import { WidgetBoxModule } from '@core/layout/widget-box/widget-box.module';
+
 import { AppTableModule } from '@shared/components/table/table.module';
+import { AppCardModule } from '@shared/components/card/card.module';
 
 import { TopExpensesComponent } from './top-expenses.component';
 
 @NgModule({
   declarations: [TopExpensesComponent],
-  imports: [WidgetBoxModule, AppTableModule, DatePipe, CurrencyPipe],
+  imports: [
+    CommonModule,
+    //
+    WidgetBoxModule,
+    AppTableModule,
+    AppCardModule,
+  ],
   exports: [TopExpensesComponent],
 })
 export class TopExpensesModule {}

--- a/src/app/shared/components/card/card.component.scss
+++ b/src/app/shared/components/card/card.component.scss
@@ -1,0 +1,30 @@
+@use 'variables' as variables;
+@use 'spacing' as spacing;
+
+.app-card {
+  & .app-card-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: spacing.$sm;
+    border-bottom: variables.$layout-border;
+    padding: spacing.$sm 0;
+  }
+
+  &:not(&:first-of-type) .app-card-row:first-of-type {
+    border-top: variables.$layout-border;
+  }
+
+  &:first-of-type .app-card-row:first-of-type {
+    padding-top: 0;
+  }
+
+  &:last-of-type .app-card-row:last-of-type {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  & .app-card-key {
+    font-weight: 500;
+  }
+}

--- a/src/app/shared/components/card/card.component.spec.ts
+++ b/src/app/shared/components/card/card.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CardComponent]
+    });
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-card',
+  template: '<ng-content></ng-content>',
+  styleUrls: ['./card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'app-card',
+  },
+})
+export class AppCardComponent {}

--- a/src/app/shared/components/card/card.module.ts
+++ b/src/app/shared/components/card/card.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { AppCardComponent } from './card.component';
+
+import { AppCardRow, AppCardKey, AppCardValue } from './shared.component';
+
+@NgModule({
+  declarations: [AppCardComponent, AppCardRow, AppCardKey, AppCardValue],
+  imports: [CommonModule],
+  exports: [AppCardComponent, AppCardRow, AppCardKey, AppCardValue],
+})
+export class AppCardModule {}

--- a/src/app/shared/components/card/shared.component.ts
+++ b/src/app/shared/components/card/shared.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-card-row',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'app-card-row',
+  },
+})
+class AppCardRow {}
+
+@Component({
+  selector: 'app-card-key',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'app-card-key',
+  },
+})
+class AppCardKey {}
+
+@Component({
+  selector: 'app-card-value',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'app-card-value',
+  },
+})
+class AppCardValue {}
+
+export { AppCardRow, AppCardKey, AppCardValue };

--- a/src/app/shared/services/media-query/media-query.model.ts
+++ b/src/app/shared/services/media-query/media-query.model.ts
@@ -1,5 +1,5 @@
 type BreakpointLevel = 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 type BreakpointRangeLimit = 'min' | 'max';
-type Breakpoint = Record<BreakpointLevel, string>;
+type Breakpoint = Record<BreakpointLevel, number>;
 
 export type { Breakpoint, BreakpointLevel, BreakpointRangeLimit };

--- a/src/app/shared/services/media-query/media-query.service.ts
+++ b/src/app/shared/services/media-query/media-query.service.ts
@@ -8,12 +8,12 @@ import { Breakpoint, BreakpointLevel, BreakpointRangeLimit } from './media-query
   providedIn: 'root',
 })
 export class MediaQueryService {
-  private readonly breakpoints: Breakpoint = {
-    sm: '570px',
-    md: '768px',
-    lg: '850px',
-    xl: '1024px',
-    xxl: '1280px',
+  public readonly breakpointsPX: Breakpoint = {
+    sm: 570,
+    md: 768,
+    lg: 850,
+    xl: 1024,
+    xxl: 1280,
   };
 
   private activeMediaQueries: { [key: string]: Observable<boolean> } = {};
@@ -38,7 +38,7 @@ export class MediaQueryService {
    */
   mediaQuery(rangeLimit: BreakpointRangeLimit, breakPoint: BreakpointLevel): Observable<boolean> {
     const mediaId = `${rangeLimit}-${breakPoint}`;
-    const mediaQueryString = `screen and  (${rangeLimit}-width: ${this.breakpoints[breakPoint]})`;
+    const mediaQueryString = `screen and  (${rangeLimit}-width: ${this.breakpointsPX[breakPoint]}px)`;
 
     const mediaQuery = window.matchMedia(mediaQueryString);
 

--- a/src/app/shared/services/media-query/media-query.service.ts
+++ b/src/app/shared/services/media-query/media-query.service.ts
@@ -4,6 +4,22 @@ import { fromEvent, map, Observable, startWith } from 'rxjs';
 
 import { Breakpoint, BreakpointLevel, BreakpointRangeLimit } from './media-query.model';
 
+/**
+ * @summary - For mobile responsiveness.
+ *
+ * @implements
+ *
+ * ```
+ * private _initMediaQuerySubscription(): void {
+ *     this._mediaQueryService.mediaQuery('max', 'xl').subscribe({
+ *       next: value => {
+ *         this.isMobile = value;
+ *         this._changeDetectorRef.markForCheck();
+ *       },
+ *     });
+ *   }
+ * ```
+ */
 @Injectable({
   providedIn: 'root',
 })


### PR DESCRIPTION
### What changes I want to bring in production with this PR?

Mobile version of the **"overview"** page.

#### Configurations ⚒️

_None_

#### UI & UX 🖌️

Responsive `<canvas>` element.
A shared card replacement component for `<app-table>`.

#### Optimizations 📈

Using `ChangeDetectionStrategy.OnPush`.

#### Bug fixing 🔨

Header box for `<app-widget-box>` component.
Using `number` instead of `string` for the media query service breakpoints.

#### Preview

<img width="1082" height="2402" alt="localhost_4200_(Pixel 7)" src="https://github.com/user-attachments/assets/be6230c8-e069-415e-b58a-16007b1aa283" />