### PR TITLE
Feat/obt 10/mobile p l report page

### DIFF
--- a/src/app/features/expenses/tracker-table/tracker-table.component.scss
+++ b/src/app/features/expenses/tracker-table/tracker-table.component.scss
@@ -25,15 +25,10 @@
   font-size: typography.$body-sm;
 }
 
-.mobile-cards-container {
-  display: grid;
-  gap: spacing.$lg;
-
-  & .app-pill-status {
-    padding: 0;
-    border: none;
-    background: transparent;
-  }
+.mobile-cards-container .app-pill-status {
+  padding: 0;
+  border: none;
+  background: transparent;
 }
 
 @media screen and (max-width: breakpoints.$lg) {

--- a/src/app/features/home/top-expenses/top-expenses.component.scss
+++ b/src/app/features/home/top-expenses/top-expenses.component.scss
@@ -1,6 +1,0 @@
-@use 'spacing' as spacing;
-
-.mobile-cards-container {
-  display: grid;
-  gap: spacing.$lg;
-}

--- a/src/app/features/profit-and-loss/profit-and-loss.component.scss
+++ b/src/app/features/profit-and-loss/profit-and-loss.component.scss
@@ -1,7 +1,20 @@
 @use 'spacing' as spacing;
+@use 'breakpoints' as breakpoints;
 
 .row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: spacing.$grid-gap-spacing;
+}
+
+@media screen and (max-width: breakpoints.$xl) {
+  .row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: breakpoints.$md) {
+  .row {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.model.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.model.ts
@@ -1,8 +1,8 @@
 import { DataSourceItem } from '@features/profit-and-loss/profit-loss-table/profit-loss-table.model';
 
-interface IsProfitMarginOptions {
+interface GetNumberValueOptions {
   item: DataSourceItem;
   key: string;
 }
 
-export type { IsProfitMarginOptions };
+export type { GetNumberValueOptions };

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.spec.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { GetNumberValuePipe } from './get-number-value.pipe';
+
+describe('RowTypeValuePipe', () => {
+  it('create an instance', () => {
+    const pipe = new GetNumberValuePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/get-number-value/get-number-value.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { type GetNumberValueOptions } from './get-number-value.pipe.model';
+
+@Pipe({
+  name: 'getNumberValue',
+})
+export class GetNumberValuePipe implements PipeTransform {
+  /**
+   * @summary - Show the appropiate textContent format.
+   *
+   * @param {GetRowTypeDictValueOptions["item"]} options.item - The `dataSource` item.
+   * @param {GetRowTypeDictValueOptions["key"]}  options.key - Column key.
+   *
+   * @public
+   * @returns {string}
+   */
+  transform(options: GetNumberValueOptions): number {
+    const { item, key } = options;
+
+    const VALUE = item[key as keyof typeof item];
+
+    if (!VALUE || typeof VALUE !== 'number') {
+      return -1;
+    }
+
+    return VALUE;
+  }
+}

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/is-info-cell/is-info-cell.pipe.model.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/is-info-cell/is-info-cell.pipe.model.ts
@@ -1,8 +1,8 @@
 import { DataSourceItem } from '@features/profit-and-loss/profit-loss-table/profit-loss-table.model';
 
 interface IsInfoCellOptions {
-  cellItem: DataSourceItem;
-  displayedColumnsItem: string;
+  item: DataSourceItem;
+  key: string;
 }
 
 export type { IsInfoCellOptions };

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/is-info-cell/is-info-cell.pipe.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/is-info-cell/is-info-cell.pipe.ts
@@ -9,18 +9,17 @@ export class IsInfoCellPipe implements PipeTransform {
   /**
    * @summary - Cell that displays some sort of "Info" text.
    *
-   * @param {IsInfoCellOptions["displayedColumnsItem"]}  options.displayedColumnsItem - Column key.
+   * @param {IsInfoCellOptions["item"]}  options.item - Actual item object data.
+   * @param {IsInfoCellOptions["key"]}  options.key - Column key.
    *
    * @public
    * @returns {boolean}
    */
   transform(options: IsInfoCellOptions): boolean {
-    const { cellItem, displayedColumnsItem } = options;
+    const { item, key } = options;
 
-    const CELL_ITEM_VALUE = cellItem[displayedColumnsItem as keyof typeof cellItem];
+    const CELL_ITEM_VALUE = item[key as keyof typeof item];
 
-    return (
-      ['type', 'yearlyTotal'].includes(displayedColumnsItem) && typeof CELL_ITEM_VALUE !== 'number'
-    );
+    return ['type', 'yearlyTotal'].includes(key) && typeof CELL_ITEM_VALUE !== 'number';
   }
 }

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/is-number-type/is-number-type-pipe.model.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/is-number-type/is-number-type-pipe.model.ts
@@ -1,8 +1,8 @@
 import { DataSourceItem } from '@features/profit-and-loss/profit-loss-table/profit-loss-table.model';
 
 interface IsNumberTypeOptions {
-  cellItem: DataSourceItem;
-  displayedColumnsItem: string;
+  item: DataSourceItem;
+  key: string;
 }
 
 export type { IsNumberTypeOptions };

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/is-number-type/is-number-type.pipe.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/is-number-type/is-number-type.pipe.ts
@@ -11,21 +11,21 @@ export class IsNumberTypePipe implements PipeTransform {
   /**
    * @summary - Check if the current item is a "usable" number, inside the template.
    *
-   * @param {IsNumberTypeOptions["cellItem"]} options.cellItem - The `dataSource` item.
-   * @param {IsNumberTypeOptions["displayedColumnsItem"]}  options.displayedColumnsItem - Column key.
+   * @param {IsNumberTypeOptions["item"]} options.item - The `dataSource` item.
+   * @param {IsNumberTypeOptions["key"]}  options.key - Column key.
    *
    * @public
    * @returns {boolean}
    */
   transform(options: IsNumberTypeOptions): boolean {
-    const { cellItem, displayedColumnsItem } = options;
+    const { item, key } = options;
 
-    const CELL_ITEM_VALUE = cellItem[displayedColumnsItem as keyof typeof cellItem];
+    const CELL_ITEM_VALUE = item[key as keyof typeof item];
 
     const EXCLUDED_NUMBERS =
-      cellItem &&
-      Object.hasOwn(cellItem, 'type') &&
-      [RowType.PROFIT_MARGINS].includes(cellItem.type! as RowType);
+      item &&
+      Object.hasOwn(item, 'type') &&
+      [RowType.PROFIT_MARGINS].includes(item.type! as RowType);
 
     return !EXCLUDED_NUMBERS && typeof CELL_ITEM_VALUE === 'number';
   }

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/is-profit-margin/is-profit-margin.pipe.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/is-profit-margin/is-profit-margin.pipe.ts
@@ -10,21 +10,21 @@ export class IsProfitMarginPipe implements PipeTransform {
   /**
    * @summary - Check if the current item is a profit margin number, so I can use the percentage sign.
    *
-   * @param {IsNumberTypeOptions["cellItem"]} options.cellItem - The `dataSource` item.
-   * @param {IsNumberTypeOptions["displayedColumnsItem"]}  options.displayedColumnsItem - Column key.
+   * @param {IsNumberTypeOptions["item"]} options.item - The `dataSource` item.
+   * @param {IsNumberTypeOptions["key"]}  options.key - Column key.
    *
    * @public
    * @returns {boolean}
    */
   transform(options: IsProfitMarginOptions): boolean {
-    const { cellItem, displayedColumnsItem } = options;
+    const { item, key } = options;
 
-    const CELL_ITEM_VALUE = cellItem[displayedColumnsItem as keyof typeof cellItem];
+    const CELL_ITEM_VALUE = item[key as keyof typeof item];
 
     const IS_PROFIT_MARGIN =
-      cellItem &&
-      Object.hasOwn(cellItem, 'type') &&
-      [RowType.PROFIT_MARGINS].includes(cellItem.type! as RowType) &&
+      item &&
+      Object.hasOwn(item, 'type') &&
+      [RowType.PROFIT_MARGINS].includes(item.type! as RowType) &&
       typeof CELL_ITEM_VALUE === 'number';
 
     return IS_PROFIT_MARGIN;

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/row-type-value/row-type-value.pipe.model.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/row-type-value/row-type-value.pipe.model.ts
@@ -1,8 +1,8 @@
 import { DataSourceItem } from '@features/profit-and-loss/profit-loss-table/profit-loss-table.model';
 
 interface GetRowTypeDictValueOptions {
-  cellItem: DataSourceItem;
-  displayedColumnsItem: string;
+  item: DataSourceItem;
+  key: string;
 }
 
 export type { GetRowTypeDictValueOptions };

--- a/src/app/features/profit-and-loss/profit-loss-table/pipes/row-type-value/row-type-value.pipe.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/pipes/row-type-value/row-type-value.pipe.ts
@@ -27,16 +27,16 @@ export class RowTypeValuePipe implements PipeTransform {
   /**
    * @summary - Show the appropiate textContent format.
    *
-   * @param {GetRowTypeDictValueOptions["cellItem"]} options.cellItem - The `dataSource` item.
-   * @param {GetRowTypeDictValueOptions["displayedColumnsItem"]}  options.displayedColumnsItem - Column key.
+   * @param {GetRowTypeDictValueOptions["item"]} options.item - The `dataSource` item.
+   * @param {GetRowTypeDictValueOptions["key"]}  options.key - Column key.
    *
    * @public
    * @returns {string}
    */
   transform(options: GetRowTypeDictValueOptions): string {
-    const { cellItem, displayedColumnsItem } = options;
+    const { item, key } = options;
 
-    const CELL_ITEM_VALUE = cellItem[displayedColumnsItem as keyof typeof cellItem];
+    const CELL_ITEM_VALUE = item[key as keyof typeof item];
 
     if (!CELL_ITEM_VALUE) {
       return '';

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.html
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.html
@@ -1,7 +1,9 @@
 <app-widget-box>
-  <h4 app-widget-box-title>P&L report</h4>
+  <app-widget-box-header>
+    <app-widget-box-title>P&L report</app-widget-box-title>
+  </app-widget-box-header>
 
-  <table app-table [dataSource]="dataSource">
+  <table app-table [dataSource]="dataSource" *ngIf="!isMobile; else mobileCardsContainer">
     <ng-container
       *ngFor="let item of displayedColumns; trackBy: trackByFnDisplayedColumns"
       [appColumnDef]="item"
@@ -59,4 +61,65 @@
       [class.divider]="row.type === RowType.DIVIDER"
     ></tr>
   </table>
+
+  <ng-template #mobileCardsContainer>
+    <div class="mobile-cards-container">
+      <ng-container *ngFor="let item of dataSource; trackBy: trackByFnDataSource">
+        <app-card *ngIf="item.type !== RowType.DIVIDER">
+          <app-card-row>
+            <app-card-key>Type</app-card-key>
+
+            <app-card-value>
+              {{
+                {
+                  cellItem: item,
+                  displayedColumnsItem: 'type',
+                } | rowTypeValue
+              }}
+            </app-card-value>
+          </app-card-row>
+
+          <ng-container *ngFor="let object of item | keyvalue">
+            <ng-container *ngIf="!['type', 'yearlyTotal'].includes(object.key)">
+              <app-card-row>
+                <app-card-key>
+                  {{ object.key }}
+                </app-card-key>
+
+                <app-card-value
+                  *ngIf="
+                    {
+                      cellItem: item,
+                      displayedColumnsItem: object.key,
+                    } | isProfitMargin
+                  "
+                >
+                  {{ object.value | number: '1.0-2' }}&percnt;
+                </app-card-value>
+
+                <app-card-value
+                  *ngIf="
+                    {
+                      cellItem: item,
+                      displayedColumnsItem: object.key,
+                    } | isNumberType
+                  "
+                >
+                  {{ object.value | currency: 'EUR' }}
+                </app-card-value>
+              </app-card-row>
+            </ng-container>
+          </ng-container>
+
+          <app-card-row>
+            <app-card-key>Yearly Total</app-card-key>
+
+            <app-card-value>
+              {{ item.yearlyTotal | currency: 'EUR' }}
+            </app-card-value>
+          </app-card-row>
+        </app-card>
+      </ng-container>
+    </div>
+  </ng-template>
 </app-widget-box>

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.html
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.html
@@ -5,38 +5,38 @@
 
   <table app-table [dataSource]="dataSource" *ngIf="!isMobile; else mobileCardsContainer">
     <ng-container
-      *ngFor="let item of displayedColumns; trackBy: trackByFnDisplayedColumns"
-      [appColumnDef]="item"
+      *ngFor="let key of displayedColumns; trackBy: trackByFnDisplayedColumns"
+      [appColumnDef]="key"
     >
       <th *appHeaderCellDef>
-        <ng-container *ngIf="item !== 'type' && item !== 'yearlyTotal'">{{ item }}</ng-container>
-        <ng-container *ngIf="item === 'yearlyTotal'">Yearly Total</ng-container>
+        <ng-container *ngIf="key !== 'type' && key !== 'yearlyTotal'">{{ key }}</ng-container>
+        <ng-container *ngIf="key === 'yearlyTotal'">Yearly Total</ng-container>
       </th>
 
-      <td app-cell *appCellDef="let cellItem">
+      <td app-cell *appCellDef="let item">
         <ng-container
           *ngIf="
             {
-              cellItem,
-              displayedColumnsItem: item,
+              item,
+              key,
             } | isNumberType
           "
         >
-          {{ cellItem[item] | currency: 'EUR' }}
+          {{ item[key] | currency: 'EUR' }}
         </ng-container>
 
         <ng-container
           *ngIf="
             {
-              cellItem,
-              displayedColumnsItem: item,
+              item,
+              key,
             } | isInfoCell
           "
         >
           {{
             {
-              cellItem,
-              displayedColumnsItem: item,
+              item,
+              key,
             } | rowTypeValue
           }}
         </ng-container>
@@ -44,12 +44,12 @@
         <ng-container
           *ngIf="
             {
-              cellItem,
-              displayedColumnsItem: item,
+              item,
+              key,
             } | isProfitMargin
           "
         >
-          {{ cellItem[item] | number: '1.0-2' }}&percnt;
+          {{ item[key] | number: '1.0-2' }}&percnt;
         </ng-container>
       </td>
     </ng-container>
@@ -66,58 +66,76 @@
     <div class="mobile-cards-container">
       <ng-container *ngFor="let item of dataSource; trackBy: trackByFnDataSource">
         <app-card *ngIf="item.type !== RowType.DIVIDER">
-          <app-card-row>
-            <app-card-key>Type</app-card-key>
-
-            <app-card-value>
-              {{
+          <ng-container *ngFor="let key of displayedColumns; trackBy: trackByFnDisplayedColumns">
+            <app-card-row
+              *ngIf="
                 {
-                  cellItem: item,
-                  displayedColumnsItem: 'type',
-                } | rowTypeValue
-              }}
-            </app-card-value>
-          </app-card-row>
+                  item,
+                  key,
+                } | isInfoCell
+              "
+            >
+              <app-card-key>Type</app-card-key>
 
-          <ng-container *ngFor="let object of item | keyvalue">
-            <ng-container *ngIf="!['type', 'yearlyTotal'].includes(object.key)">
-              <app-card-row>
-                <app-card-key>
-                  {{ object.key }}
-                </app-card-key>
+              <app-card-value>
+                {{
+                  {
+                    item,
+                    key,
+                  } | rowTypeValue
+                }}
+              </app-card-value>
+            </app-card-row>
 
-                <app-card-value
-                  *ngIf="
-                    {
-                      cellItem: item,
-                      displayedColumnsItem: object.key,
-                    } | isProfitMargin
-                  "
-                >
-                  {{ object.value | number: '1.0-2' }}&percnt;
-                </app-card-value>
+            <app-card-row
+              *ngIf="
+                !(
+                  {
+                    item,
+                    key,
+                  } | isInfoCell
+                )
+              "
+            >
+              <app-card-key>{{ key !== 'yearlyTotal' ? key : 'Yearly Total' }}</app-card-key>
 
-                <app-card-value
-                  *ngIf="
-                    {
-                      cellItem: item,
-                      displayedColumnsItem: object.key,
-                    } | isNumberType
-                  "
-                >
-                  {{ object.value | currency: 'EUR' }}
-                </app-card-value>
-              </app-card-row>
-            </ng-container>
+              <app-card-value
+                *ngIf="
+                  {
+                    item,
+                    key,
+                  } | isNumberType
+                "
+              >
+                {{
+                  {
+                    item,
+                    key,
+                  }
+                    | getNumberValue
+                    | currency: 'EUR'
+                }}
+              </app-card-value>
+
+              <app-card-value
+                *ngIf="
+                  {
+                    item,
+                    key,
+                  } | isProfitMargin
+                "
+              >
+                {{
+                  {
+                    item,
+                    key,
+                  }
+                    | getNumberValue
+                    | number: '1.0-2'
+                }}&percnt;
+              </app-card-value>
+            </app-card-row>
           </ng-container>
-
-          <app-card-row>
-            <app-card-key>Yearly Total</app-card-key>
-
-            <app-card-value>
-              {{ item.yearlyTotal | currency: 'EUR' }}
-            </app-card-value>
-          </app-card-row>
         </app-card>
       </ng-container>
     </div>

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.ts
@@ -98,6 +98,23 @@ export class ProfitLossTableComponent implements OnInit {
   }
 
   /**
+   * @summary - For an optimized loop block.
+   *
+   * @param {number} index - Current index.
+   * @param {DataSourceItem} item - Current item in iteration.
+   *
+   * @returns {number}
+   * @public
+   */
+  public trackByFnDataSource(index: number, item: DataSourceItem): string | number {
+    if (typeof item.type !== 'string') {
+      return index;
+    }
+
+    return item.type;
+  }
+
+  /**
    * @summary - Format displayed columns.
    *
    * @private
@@ -243,23 +260,6 @@ export class ProfitLossTableComponent implements OnInit {
         this._changeDetectorRef.markForCheck();
       },
     });
-  }
-
-  /**
-   * @summary - For an optimized loop block.
-   *
-   * @param {number} index - Current index.
-   * @param {DataSourceItem} item - Current item in iteration.
-   *
-   * @returns {number}
-   * @public
-   */
-  public trackByFnDataSource(index: number, item: DataSourceItem): string | number {
-    if (typeof item.type !== 'string') {
-      return index;
-    }
-
-    return item.type;
   }
 
   ngOnInit(): void {

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.component.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { type OnInit, ChangeDetectionStrategy, Component, ChangeDetectorRef } from '@angular/core';
+
+import { MediaQueryService } from '@shared/services/media-query/media-query.service';
 
 import {
   Months,
@@ -16,10 +18,28 @@ import {
   styleUrls: ['./profit-loss-table.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProfitLossTableComponent {
+export class ProfitLossTableComponent implements OnInit {
   public readonly Months = Months;
   public readonly RowType = RowType;
   public displayedColumns: DisplayedColumns = [];
+
+  /**
+   * @summary - Actual data used by our table component.
+   *
+   * @type {DataSource}
+   *
+   * @public
+   */
+  public dataSource: DataSource = [];
+
+  /**
+   * @summary - Change whatever on mobile devices.
+   *
+   * @type {boolean}
+   *
+   * @public
+   */
+  public isMobile: boolean = false;
 
   private _dataSourceRevenue: DataSourceMonths = {
     [Months.JANUARY]: 12,
@@ -51,14 +71,18 @@ export class ProfitLossTableComponent {
     [Months.DECEMBER]: 12,
   };
 
-  /**
-   * @summary - Actual data used by our table component.
-   *
-   * @type {DataSource}
-   *
-   * @public
-   */
-  public dataSource: DataSource = [];
+  private readonly _mediaQueryService: MediaQueryService;
+  private readonly _changeDetectorRef: ChangeDetectorRef;
+
+  constructor(mediaQueryService: MediaQueryService, changeDetectorRef: ChangeDetectorRef) {
+    this._initDisplayedColumns();
+    this._initSetDataSource();
+    this._initSetGrossProfit();
+    this._initSetProfitMargins();
+
+    this._mediaQueryService = mediaQueryService;
+    this._changeDetectorRef = changeDetectorRef;
+  }
 
   /**
    * @summary - Track by fn for displayed columns.
@@ -135,12 +159,16 @@ export class ProfitLossTableComponent {
       yearlyTotal: YEARLY_TOTAL,
     };
 
-    this.dataSource.push(
-      {
-        type: RowType.DIVIDER,
-      },
-      ITEM
+    const DATA = Object.assign(
+      {},
+      !this.isMobile
+        ? {
+            type: RowType.DIVIDER,
+          }
+        : null
     );
+
+    this.dataSource.push(DATA, ITEM);
   }
 
   /**
@@ -202,10 +230,39 @@ export class ProfitLossTableComponent {
     return ITEM;
   }
 
-  constructor() {
-    this._initDisplayedColumns();
-    this._initSetDataSource();
-    this._initSetGrossProfit();
-    this._initSetProfitMargins();
+  /**
+   * @summary - Init media query subscription.
+   *
+   * @private
+   * @returns {void}
+   */
+  private _initMediaQuerySubscription(): void {
+    this._mediaQueryService.mediaQuery('max', 'xl').subscribe({
+      next: value => {
+        this.isMobile = value;
+        this._changeDetectorRef.markForCheck();
+      },
+    });
+  }
+
+  /**
+   * @summary - For an optimized loop block.
+   *
+   * @param {number} index - Current index.
+   * @param {DataSourceItem} item - Current item in iteration.
+   *
+   * @returns {number}
+   * @public
+   */
+  public trackByFnDataSource(index: number, item: DataSourceItem): string | number {
+    if (typeof item.type !== 'string') {
+      return index;
+    }
+
+    return item.type;
+  }
+
+  ngOnInit(): void {
+    this._initMediaQuerySubscription();
   }
 }

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.module.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
-import { CommonModule, CurrencyPipe, NgFor, NgIf, DecimalPipe } from '@angular/common';
+import { CommonModule, CurrencyPipe, DecimalPipe, KeyValuePipe } from '@angular/common';
 
 import { WidgetBoxModule } from '@core/layout/widget-box/widget-box.module';
+
 import { AppTableModule } from '@shared/components/table/table.module';
+import { AppCardModule } from '@shared/components/card/card.module';
 
 import { IsNumberTypePipe } from './pipes/is-number-type/is-number-type.pipe';
 import { IsInfoCellPipe } from './pipes/is-info-cell/is-info-cell.pipe';
@@ -23,14 +25,14 @@ import { ProfitLossTableComponent } from './profit-loss-table.component';
   imports: [
     // Angular specific
     CommonModule,
-    NgFor,
-    NgIf,
     // Pipes
     CurrencyPipe,
     DecimalPipe,
+    KeyValuePipe,
     // App specific
     WidgetBoxModule,
     AppTableModule,
+    AppCardModule,
   ],
   exports: [ProfitLossTableComponent],
 })

--- a/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.module.ts
+++ b/src/app/features/profit-and-loss/profit-loss-table/profit-loss-table.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { CommonModule, CurrencyPipe, DecimalPipe, KeyValuePipe } from '@angular/common';
+import { CommonModule, CurrencyPipe, DecimalPipe, KeyValuePipe, NgIf } from '@angular/common';
 
 import { WidgetBoxModule } from '@core/layout/widget-box/widget-box.module';
 
@@ -10,6 +10,7 @@ import { IsNumberTypePipe } from './pipes/is-number-type/is-number-type.pipe';
 import { IsInfoCellPipe } from './pipes/is-info-cell/is-info-cell.pipe';
 import { RowTypeValuePipe } from './pipes/row-type-value/row-type-value.pipe';
 import { IsProfitMarginPipe } from './pipes/is-profit-margin/is-profit-margin.pipe';
+import { GetNumberValuePipe } from './pipes/get-number-value/get-number-value.pipe';
 
 import { ProfitLossTableComponent } from './profit-loss-table.component';
 
@@ -21,6 +22,7 @@ import { ProfitLossTableComponent } from './profit-loss-table.component';
     IsInfoCellPipe,
     RowTypeValuePipe,
     IsProfitMarginPipe,
+    GetNumberValuePipe,
   ],
   imports: [
     // Angular specific

--- a/src/app/shared/components/card/card.component.scss
+++ b/src/app/shared/components/card/card.component.scss
@@ -1,5 +1,8 @@
+@use 'sass:map';
+
 @use 'variables' as variables;
 @use 'spacing' as spacing;
+@use 'color-palette' as color-palette;
 
 .app-card {
   & .app-card-row {
@@ -8,20 +11,19 @@
     align-items: center;
     gap: spacing.$sm;
     border-bottom: variables.$layout-border;
-    padding: spacing.$sm 0;
+    padding: spacing.$sm;
   }
 
   &:not(&:first-of-type) .app-card-row:first-of-type {
     border-top: variables.$layout-border;
   }
 
-  &:first-of-type .app-card-row:first-of-type {
-    padding-top: 0;
+  & .app-card-row:first-of-type {
+    background: map.get(color-palette.$gray, 'default');
   }
 
   &:last-of-type .app-card-row:last-of-type {
     border-bottom: none;
-    padding-bottom: 0;
   }
 
   & .app-card-key {

--- a/src/app/shared/services/media-query/media-query.service.ts
+++ b/src/app/shared/services/media-query/media-query.service.ts
@@ -18,6 +18,10 @@ import { Breakpoint, BreakpointLevel, BreakpointRangeLimit } from './media-query
  *       },
  *     });
  *   }
+ *
+ *  ngOnInit(): void {
+ *    this._initMediaQuerySubscription();
+ *  }
  * ```
  */
 @Injectable({

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -1,8 +1,15 @@
 @use 'sass:map';
 
-@use 'variables' as *;
-@use 'functions' as *;
-@use 'spacing' as *;
+@use 'variables' as variables;
+@use 'functions' as functions;
+@use 'spacing' as spacing;
+
+$spacing: (
+  'sm': spacing.$sm,
+  'default': spacing.$default,
+  'md': spacing.$md,
+  'lg': spacing.$lg,
+);
 
 /* Default Theme */
 .overlay {
@@ -297,8 +304,8 @@
     display: flex;
 
     &.justify-content {
-      @each $value in map.get($grid, 'justify-content') {
-        $class-name: getGridClassName($value);
+      @each $value in map.get(variables.$grid, 'justify-content') {
+        $class-name: functions.getGridClassName($value);
 
         &-#{$class-name} {
           justify-content: $value;
@@ -307,8 +314,8 @@
     }
 
     &.align-items {
-      @each $value in map.get($grid, 'align-items') {
-        $class-name: getGridClassName($value);
+      @each $value in map.get(variables.$grid, 'align-items') {
+        $class-name: functions.getGridClassName($value);
 
         &-#{$class-name} {
           align-items: $value;
@@ -317,11 +324,16 @@
     }
 
     &.flex {
-      @each $value in map.get($grid, 'direction') {
+      @each $value in map.get(variables.$grid, 'direction') {
         &-#{$value} {
           direction: $value;
         }
       }
     }
   }
+}
+
+.mobile-cards-container {
+  display: grid;
+  gap: spacing.$lg;
 }


### PR DESCRIPTION
### PR Summary

Mobile version for the `/profit-and-loss` path.

#### Configurations ⚒️

_None_

#### UI & UX 🖌️

_None_

#### Optimizations/Improvements 📈

Naming convention for custom pipes, for the P & L page.
Using namespaces for the `_utils.scss` partial file.

#### Bug fixing 🔨

_None_

#### Preview

<img width="1125" height="2436" alt="localhost_4200_profit-and-loss(iPhone X)" src="https://github.com/user-attachments/assets/a3dab207-e271-4e78-a9a7-a307c8361fbf" />